### PR TITLE
Corrected number of iterations in UFFOptimizeMolecule documentation

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
@@ -61,7 +61,7 @@ BOOST_PYTHON_MODULE(rdForceFieldHelpers) {
  \n\
  ARGUMENTS:\n\n\
     - mol : the molecule of interrest\n\
-    - maxIters : the maximum number of iterations (defaults to 100)\n\
+    - maxIters : the maximum number of iterations (defaults to 200)\n\
     - vdwThresh : used to exclude long-range van der Waals interactions\n\
                   (defaults to 10.0)\n\
     - confId : indicates which conformer to optimize\n\


### PR DESCRIPTION
Says 100, it should be 200.
