### PR TITLE
Compatibility with sdf files served by the PDB

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -760,9 +760,9 @@ namespace RDKit{
         errout << "Cannot process coordinates on line "<<line;
         throw FileParseException(errout.str()) ;
       }
-      symb = text.substr(31,3);
-      symb = symb.substr(0,symb.find(' '));
-    
+      symb = text.substr(31,4);
+      boost::erase_all(symb, " ");
+      
       // REVIEW: should we handle missing fields at the end of the line?
       massDiff=0;
       if(text.size()>=36 && text.substr(34,2)!=" 0"){


### PR DESCRIPTION
SDFs provided by the PDB (Protein Data Bank) have a slightly different format than what RDKit is expecting.

http://www.rcsb.org/pdb/download/downloadLigandFiles.do?ligandIdList=XK2&structIdList=1HVR&instanceType=all&excludeUnobserved=false&includeHydrogens=false
