### PR TITLE
Compatibility with sdf files served by the PDB

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -761,8 +761,8 @@ namespace RDKit{
         throw FileParseException(errout.str()) ;
       }
       symb = text.substr(31,3);
-      symb = symb.substr(0,symb.find(' '));
-    
+      boost::erase_all(symb, " ");
+      
       // REVIEW: should we handle missing fields at the end of the line?
       massDiff=0;
       if(text.size()>=36 && text.substr(34,2)!=" 0"){


### PR DESCRIPTION
SDFs provided by the PDB (Protein Data Bank) have a slightly different format than what RDKit is expecting.

Example file that would fail with the old code
http://www.rcsb.org/pdb/download/downloadLigandFiles.do?ligandIdList=XK2&structIdList=1HVR&instanceType=all&excludeUnobserved=false&includeHydrogens=false

The old error was:

---

Post-condition Violation
Element '' not found
Violation occurred on line 91 in file /home/jandom/workspace/rdkit/Code/GraphMol/PeriodicTable.h
Failed Expression: anum>-1

---
